### PR TITLE
Add 1 click copy for install commands in quickstart, fix broken link

### DIFF
--- a/website/docs/Usage/Hardware.md
+++ b/website/docs/Usage/Hardware.md
@@ -20,7 +20,7 @@ of storage initially, as of Jan 2024. The on-disk growth pattern differs between
 [resource use](../Usage/ResourceUsage.md).
 
 If you have a 2TB disk, it is expected to last (potentially with execution client pruning) until early 2025.
-Remy wrote a [migration guide to 4TB](https://github.com/ethstaker/ethstaker-guides/blob/main/docs/migrating-to-a-larger-disk.md).
+Remy wrote a [migration guide to 4TB](https://docs.ethstaker.org/guides/monitoring-maintenance/migrating-to-a-larger-disk/).
 Also keep an eye on [EIP-4444](https://eips.ethereum.org/EIPS/eip-4444).
 
 Two home server builds that I like and am happy to recommend are below. Both Intel and AMD support IPMI, which means

--- a/website/docs/Usage/Hardware.md
+++ b/website/docs/Usage/Hardware.md
@@ -20,7 +20,7 @@ of storage initially, as of Jan 2024. The on-disk growth pattern differs between
 [resource use](../Usage/ResourceUsage.md).
 
 If you have a 2TB disk, it is expected to last (potentially with execution client pruning) until early 2025.
-Remy wrote a [migration guide to 4TB](https://github.com/ethstaker/ethstaker-guides/blob/main/migrating-to-a-larger-disk.md).
+Remy wrote a [migration guide to 4TB](https://github.com/ethstaker/ethstaker-guides/blob/main/docs/migrating-to-a-larger-disk.md).
 Also keep an eye on [EIP-4444](https://eips.ethereum.org/EIPS/eip-4444).
 
 Two home server builds that I like and am happy to recommend are below. Both Intel and AMD support IPMI, which means

--- a/website/docs/Usage/QuickStart.md
+++ b/website/docs/Usage/QuickStart.md
@@ -17,29 +17,51 @@ Take a look at some [build ideas](../Usage/Hardware.md) and consider clients' [r
 For a rapid start, have Ubuntu or Debian Linux installed, and then follow these steps. This has been tested on Debian
 LTS and Ubuntu LTS.
 
-> If you are using a version of Debian with a root password set, please install `sudo` as the `root` user with
-> `apt update && apt install sudo git`, then make your non-root user a member of the sudo group with
-> `usermod -aG sudo <username>`.
+<details>
+<summary>If you are using a version of Debian with a root password set</summary>
 
-> If you are using a minimal version of Ubuntu or Debian, please install `git` with `sudo apt update && sudo apt install git`
+please install `sudo` as the `root` user with
+
+```bash
+apt update && apt install sudo -y
+```
+
+then make your non-root user a member of the sudo group with
+
+```bash
+usermod -aG sudo <username>
+```
 
 Eth Docker needs to be installed while logged into a user account other than `root`, for security purposes.
+</details>
+
+Make sure `git` is installed
+
+```bash
+sudo apt update && sudo apt install git -y
+```
+
+
 
 Download Eth Docker
-
-`cd ~ && git clone https://github.com/ethstaker/eth-docker.git && cd eth-docker`
+```bash
+cd ~ && git clone https://github.com/ethstaker/eth-docker.git && cd eth-docker
+```
 
 Install pre-requisites such as Docker
-
-`./ethd install`
+```bash
+./ethd install
+```
 
 Configure Eth Docker - have an Ethereum address handy where you want Execution Layer rewards to go
-
-`./ethd config`
+```bash
+./ethd config
+```
 
 Start Eth Docker
-
-`./ethd up`
+```bash
+./ethd up
+```
 
 The same script can also be used to stop, start and update the node. Run `./ethd` for a help screen.
 


### PR DESCRIPTION
• put the key install commands in prominent 1 click to copy code blocks to make them easier to locate and copy when wanting to quickly install eth-docker

• put the commands needed for Debian with root password in their own expanding section to keep it separate and make it less confusing for the basic ubuntu users

• fix broken link to Remys 4 tb migration guide


### Current page:

<img width="975" height="688" alt="image" src="https://github.com/user-attachments/assets/f95a0aed-73a8-4e68-be0f-1687db7bd508" />



### After this change:

<img width="975" height="1084" alt="image" src="https://github.com/user-attachments/assets/7f6bcf6c-1836-40e0-b11b-cc229961c5ee" />



### After clicking to expand Debian section:

<img width="975" height="858" alt="image" src="https://github.com/user-attachments/assets/11f1bf50-8f9b-4817-a1ce-4da59c17651d" />
