### PR TITLE
docs: Add comprehensive Grafana Cloud configuration guide and fix Alloy tracing errors

### DIFF
--- a/website/docs/Usage/Dashboards.md
+++ b/website/docs/Usage/Dashboards.md
@@ -7,13 +7,18 @@ sidebar_label: Dashboards
 ## Choose local or cloud Grafana
 
 You have a choice of running Grafana locally, by including `grafana.yml`, or in the cloud, with `grafana-cloud.yml`.
-If you choose Grafana Cloud, you **must** edit `./alloy/prometheus-write.alloy` as well as `./alloy/loki-write.alloy`
-and add your cloud remote write credentials. This can also be used to write to a central Grafana stack of your own,
-rather than a hosted cloud offering.
 
-`grafana-cloud.yml` runs a local Alloy but no local Grafana, and enables adding custom Alloy config items.
+### Grafana Cloud Configuration
 
-If you want to add additional scrape targets, place these into `./alloy`.
+If you choose Grafana Cloud, you **must** edit `./alloy/prometheus-write.alloy` as well as `./alloy/loki-write.alloy` and add your cloud remote write credentials. This can also be used to write to a central Grafana stack of your own, rather than a hosted cloud offering.
+
+1. **Metrics**: Edit `./alloy/prometheus-write.alloy`, uncomment `prometheus.remote_write.remote_prometheus.receiver` in the `forward_to` array, and update the `remote_prometheus` block with your Grafana Cloud Mimir endpoint and credentials.
+2. **Logs**: Edit `./alloy/loki-write.alloy`, uncomment `loki.write.remote_loki.receiver` in the `forward_to` array, and update the `remote_loki` block with your Grafana Cloud Loki endpoint and credentials.
+3. **Traces (Important)**: The default `./alloy/alloy-logs.alloy` is configured to send traces to a local `tempo` service. However, `grafana-cloud.yml` does **not** include a local Tempo container. If left unchanged, Alloy will fail to start with a `"no children to pick from"` error. You have two options:
+   - **Option A (Recommended)**: Comment out the `tracing` and `otelcol.exporter.otlp "tempo"` blocks in `./alloy/alloy-logs.alloy` if you only need metrics and logs.
+   - **Option B**: Update the `otelcol.exporter.otlp "tempo"` block to point to your Grafana Cloud Tempo endpoint. **Note:** The `auth` parameter inside the `client` block must be an **attribute** (`auth = otelcol.auth.basic.grafana_cloud.handler`), not a block (`auth { ... }`). Using a block will cause a syntax error.
+
+`grafana-cloud.yml` runs a local Alloy but no local Grafana, and enables adding custom Alloy config items. If you want to add additional scrape targets, place these into `./alloy`.
 
 ## Local Grafana dashboards
 


### PR DESCRIPTION
    Summary  
    This PR updates the "Dashboards" documentation (website/docs/Usage/Dashboards.md) to provide clear, step-by-step instructions for configuring Grafana Cloud remote write (Metrics, Logs, and Traces). It specifically addresses and documents common startup errors users encounter when switching from local Grafana to grafana-cloud.yml.
    
    Problem Solved  
    Users configuring Grafana Cloud frequently hit two roadblocks that are not currently documented:
    1. Missing Tempo Container: The default alloy/alloy-logs.alloy is configured to send traces to a local tempo service (endpoint = "tempo:4317"). However, grafana-cloud.yml does not include a local Tempo container. If left unchanged, the Alloy container fails to start with the error: "no children to pick from".
    2. River Syntax Error: When users attempt to fix the tracing issue by pointing the exporter to Grafana Cloud Tempo, they often write the authentication as a block (auth { ... }). In Grafana Alloy's River language, this causes a fatal syntax error: expected TERMINATOR, got =.
    
    Changes Made  
    - Restructured the "Choose local or cloud Grafana" section into a clear, actionable "Grafana Cloud Configuration" guide.
    - Added explicit, numbered steps for configuring Metrics (prometheus-write.alloy) and Logs (loki-write.alloy).
    - Added a critical "Traces (Important)" subsection that clearly explains the two valid solutions:
      - Option A (Recommended): Comment out the tracing blocks entirely if only metrics and logs are needed.
      - Option B: Correctly configure the remote Tempo endpoint, with an explicit warning that auth must be an attribute (auth = otelcol.auth.basic.grafana_cloud.handler), not a block.
    
    Testing / Verification  
    - Verified the River syntax against official Grafana Alloy documentation.
    - Confirmed that applying these exact steps resolves the "no children to pick from" and syntax errors in a live eth-docker environment running grafana-cloud.yml.